### PR TITLE
Fixes the elements of the bidding for the engineer role

### DIFF
--- a/controllers/biddings/crud/index.js
+++ b/controllers/biddings/crud/index.js
@@ -413,6 +413,7 @@ async function filterIdBiddingByRole (bidding, role, email, boolDeadlines) {
       bidderCompany: bidding.bidderCompany,
       users: bidding.users,
       questions: bidding.questions,
+      notices: bidding.notices,
       deadlines: bidding.deadlines,
       publishedResults: bidding.publishedResults,
       permissions: permissions


### PR DESCRIPTION
This branch was created to add the "notices" element from the DB to the bidding model that the engineer role receives from the backend.